### PR TITLE
Basic plotting functionality

### DIFF
--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
@@ -22,6 +22,10 @@ Analog_Viewer::Analog_Viewer(Media_Window *scene, std::shared_ptr<DataManager> d
     ui(new Ui::Analog_Viewer)
 {
     ui->setupUi(this);
+
+    connect(ui->linechoose_cbox, &QComboBox::currentTextChanged, this, &Analog_Viewer::ResetLineEditor);
+    connect(ui->ymult_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::ElementSetLintrans);
+    connect(ui->yoffset_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::ElementSetLintrans);
 }
 
 Analog_Viewer::~Analog_Viewer() {
@@ -31,6 +35,10 @@ Analog_Viewer::~Analog_Viewer() {
 void Analog_Viewer::openWidget()
 {
     std::cout << "Analog Viewer Opened" << std::endl;
+
+    for (auto name : _data_manager->getAnalogTimeSeriesKeys()) {
+        plotLine(name);
+    }
 
     this->show();
 }
@@ -45,24 +53,37 @@ void Analog_Viewer::SetFrame(int i){
  * @brief Plot a line on the analog viewer
  * @param data Vector indexed by frame number 
  */
-void Analog_Viewer::plotLine(std::string name, std::vector<double>& data){
+void Analog_Viewer::plotLine(std::string name){
+    auto data = _data_manager->getAnalogTimeSeries(name)->getAnalogTimeSeries();
     if (_plot_elements.find(name) != _plot_elements.end()) {
-        std::cout << "Plot element named " << name << " already exists, choose another name" << std::endl;
+        std::cout << "Plot element named " << name << " already exists, ignoring" << std::endl;
         return;
     }
+
+    PlotElementInfo element;
 
     JKQTPDatastore* ds = ui->plot->getDatastore();
     std::vector<int> frame_numbers(data.size());
     iota(frame_numbers.begin(), frame_numbers.end(), 0);
-    size_t columnX=ds->addCopiedColumn(frame_numbers, QString::fromStdString(name+"_x"));
-    size_t columnY=ds->addCopiedColumn(data, QString::fromStdString(name+"_y"));
+    size_t x_col=ds->addCopiedColumn(frame_numbers, QString::fromStdString(name+"_x"));
+    size_t y_col=ds->addCopiedColumn(data, QString::fromStdString(name+"_y_trans"));
+
+    element.ds_y_col = y_col;
+    element.mult = 1.0;
+    element.add = 0.0;
 
     JKQTPXYLineGraph* graph=new JKQTPXYLineGraph(ui->plot);
-    graph->setXColumn(columnX);
-    graph->setYColumn(columnY);
+    graph->setSymbolType(JKQTPNoSymbol);
+    graph->setXColumn(x_col);
+    graph->setYColumn(y_col);
     graph->setTitle(QObject::tr(name.c_str()));
 
-    _plot_elements[name] = graph;
+    element.element = graph;
+
+    _plot_elements[name] = element;
+
+    ui->linechoose_cbox->addItem(QString::fromStdString(name));
+
     ui->plot->addGraph(graph);
 }
 
@@ -72,7 +93,36 @@ void Analog_Viewer::removeGraph(std::string name){
         return;
     }
 
-    JKQTPPlotElement* graph = _plot_elements[name];
+    JKQTPPlotElement* graph = _plot_elements[name].element;
     ui->plot->deleteGraph(graph);
     _plot_elements.erase(name);
+}
+
+void Analog_Viewer::_element_apply_lintrans(std::string name){
+    if (_plot_elements.find(name) == _plot_elements.end()) {
+        std::cout << "Plot element named " << name << " does not exist" << std::endl;
+        return;
+    } 
+
+    auto ds = ui->plot->getDatastore();
+    auto data = _data_manager->getAnalogTimeSeries(name)->getAnalogTimeSeries();
+    for (int i=0; i<data.size(); i++) {
+        ds->set(_plot_elements[name].ds_y_col, i, data[i]*_plot_elements[name].mult+_plot_elements[name].add);
+    }
+}
+
+void Analog_Viewer::ElementSetLintrans(){
+    std::string name = ui->linechoose_cbox->currentText().toStdString();
+    if (!name.empty()) {
+        _plot_elements[name].mult = ui->ymult_dspinbox->value();
+        _plot_elements[name].add = ui->yoffset_dspinbox->value();
+        _element_apply_lintrans(name);
+        ui->plot->redrawPlot();
+    }
+}
+
+void Analog_Viewer::ResetLineEditor(){
+    std::string name = ui->linechoose_cbox->currentText().toStdString();
+    ui->ymult_dspinbox->setValue(_plot_elements[name].mult);
+    ui->yoffset_dspinbox->setValue(_plot_elements[name].add);
 }

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
@@ -40,7 +40,7 @@ void Analog_Viewer::openWidget()
     for (auto name : _data_manager->getAnalogTimeSeriesKeys()) {
         plotLine(name);
     }
-    _setZoom(0);
+    _setZoom();
 
     this->show();
 }
@@ -48,7 +48,8 @@ void Analog_Viewer::openWidget()
 void Analog_Viewer::SetFrame(int i){
     std::cout << "Analog Viewer: Set Frame " << i << std::endl;
 
-    _setZoom(i);
+    _current_frame = i;
+    _setZoom();
 }
 
 /**
@@ -129,10 +130,10 @@ void Analog_Viewer::ResetLineEditor(){
     ui->yoffset_dspinbox->setValue(_plot_elements[name].add);
 }
 
-void Analog_Viewer::_setZoom(int i){
-    ui->plot->zoom(i - ui->xwidth_dspinbox->value()/2, i + ui->xwidth_dspinbox->value()/2, -10, 10);
+void Analog_Viewer::_setZoom(){
+    ui->plot->zoom(_current_frame - ui->xwidth_dspinbox->value()/2, _current_frame + ui->xwidth_dspinbox->value()/2, -10, 10);
 }
 
-void Analog_Viewer::SetZoom(int i){
-    _setZoom(i);
+void Analog_Viewer::SetZoom(){
+    _setZoom();
 }

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
@@ -2,16 +2,32 @@
 // Created by wanglab on 4/15/2024.
 //
 
+#include <QMainWindow>
+#include <QPointer>
+
 #include "analog_viewer.hpp"
 #include "ui_analog_viewer.h"
 
+#include "jkqtplotter/jkqtplotter.h"
+#include "jkqtplotter/graphs/jkqtplines.h"
+#include "jkqtplotter/graphs/jkqtpparsedfunction.h"
+
 #include <iostream>
 
-Analog_Viewer::Analog_Viewer(QWidget *parent) :
-    QWidget(parent),
+Analog_Viewer::Analog_Viewer(Media_Window *scene, std::shared_ptr<DataManager> data_manager, TimeScrollBar* time_scrollbar, QWidget *parent) :
+    QMainWindow(parent),
+    _scene{scene},
+    _data_manager{data_manager},
+    _time_scrollbar{time_scrollbar},
     ui(new Ui::Analog_Viewer)
 {
     ui->setupUi(this);
+
+    JKQTPXParsedFunctionLineGraph* graph = new JKQTPXParsedFunctionLineGraph(ui->plot);
+    graph->setFunction("y=x^3-4*x");
+    graph->setTitle("Some function");
+    ui->plot->addGraph(graph);
+    ui->plot->setXY(-10,10,-10,10);
 }
 
 Analog_Viewer::~Analog_Viewer() {
@@ -22,14 +38,9 @@ void Analog_Viewer::openWidget()
 {
     std::cout << "Analog Viewer Opened" << std::endl;
 
-    // connect(this->trace_button,SIGNAL(clicked()),this,SLOT(TraceButton()));
-    /*
-    connect(_scene, SIGNAL(leftClick(qreal, qreal)), this,
-            SLOT(_ClickedInVideo(qreal, qreal)));
-    connect(ui->saveLabelsButton, SIGNAL(clicked()), this, SLOT(_saveButton()));
-
-    connect(ui->label_name_box, SIGNAL(textChanged()), this,
-            SLOT(_changeLabelName()));
-    */
     this->show();
+}
+
+void Analog_Viewer::SetFrame(int i){
+    std::cout << "Analog Viewer: Set Frame " << i << std::endl;
 }

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
@@ -59,7 +59,9 @@ void Analog_Viewer::SetFrame(int i){
 void Analog_Viewer::plotLine(std::string name){
     auto data = _data_manager->getAnalogTimeSeries(name)->getAnalogTimeSeries();
     if (_plot_elements.find(name) != _plot_elements.end()) {
-        std::cout << "Plot element named " << name << " already exists, ignoring" << std::endl;
+        std::cout << "Plot element named " << name << " already exists, data has been replaced" << std::endl;
+        _elementApplyLintrans(name);
+        ui->plot->redrawPlot();
         return;
     }
 

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
@@ -10,7 +10,7 @@
 
 #include "jkqtplotter/jkqtplotter.h"
 #include "jkqtplotter/graphs/jkqtplines.h"
-#include "jkqtplotter/graphs/jkqtpparsedfunction.h"
+#include "jkqtplotter/jkqtpgraphsbase.h"
 
 #include <iostream>
 
@@ -22,12 +22,6 @@ Analog_Viewer::Analog_Viewer(Media_Window *scene, std::shared_ptr<DataManager> d
     ui(new Ui::Analog_Viewer)
 {
     ui->setupUi(this);
-
-    JKQTPXParsedFunctionLineGraph* graph = new JKQTPXParsedFunctionLineGraph(ui->plot);
-    graph->setFunction("y=x^3-4*x");
-    graph->setTitle("Some function");
-    ui->plot->addGraph(graph);
-    ui->plot->setXY(-10,10,-10,10);
 }
 
 Analog_Viewer::~Analog_Viewer() {
@@ -43,4 +37,42 @@ void Analog_Viewer::openWidget()
 
 void Analog_Viewer::SetFrame(int i){
     std::cout << "Analog Viewer: Set Frame " << i << std::endl;
+
+    ui->plot->zoom(i-5, i+5, -10, 10);
+}
+
+/**
+ * @brief Plot a line on the analog viewer
+ * @param data Vector indexed by frame number 
+ */
+void Analog_Viewer::plotLine(std::string name, std::vector<double>& data){
+    if (_plot_elements.find(name) != _plot_elements.end()) {
+        std::cout << "Plot element named " << name << " already exists, choose another name" << std::endl;
+        return;
+    }
+
+    JKQTPDatastore* ds = ui->plot->getDatastore();
+    std::vector<int> frame_numbers(data.size());
+    iota(frame_numbers.begin(), frame_numbers.end(), 0);
+    size_t columnX=ds->addCopiedColumn(frame_numbers, QString::fromStdString(name+"_x"));
+    size_t columnY=ds->addCopiedColumn(data, QString::fromStdString(name+"_y"));
+
+    JKQTPXYLineGraph* graph=new JKQTPXYLineGraph(ui->plot);
+    graph->setXColumn(columnX);
+    graph->setYColumn(columnY);
+    graph->setTitle(QObject::tr(name.c_str()));
+
+    _plot_elements[name] = graph;
+    ui->plot->addGraph(graph);
+}
+
+void Analog_Viewer::removeGraph(std::string name){
+    if (_plot_elements.find(name) == _plot_elements.end()) {
+        std::cout << "Plot element named " << name << " does not exist" << std::endl;
+        return;
+    }
+
+    JKQTPPlotElement* graph = _plot_elements[name];
+    ui->plot->deleteGraph(graph);
+    _plot_elements.erase(name);
 }

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
@@ -26,6 +26,7 @@ Analog_Viewer::Analog_Viewer(Media_Window *scene, std::shared_ptr<DataManager> d
     connect(ui->linechoose_cbox, &QComboBox::currentTextChanged, this, &Analog_Viewer::ResetLineEditor);
     connect(ui->ymult_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::ElementSetLintrans);
     connect(ui->yoffset_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::ElementSetLintrans);
+    connect(ui->xwidth_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::SetZoom);
 }
 
 Analog_Viewer::~Analog_Viewer() {
@@ -39,6 +40,7 @@ void Analog_Viewer::openWidget()
     for (auto name : _data_manager->getAnalogTimeSeriesKeys()) {
         plotLine(name);
     }
+    _setZoom(0);
 
     this->show();
 }
@@ -46,7 +48,7 @@ void Analog_Viewer::openWidget()
 void Analog_Viewer::SetFrame(int i){
     std::cout << "Analog Viewer: Set Frame " << i << std::endl;
 
-    ui->plot->zoom(i-5, i+5, -10, 10);
+    _setZoom(i);
 }
 
 /**
@@ -98,7 +100,7 @@ void Analog_Viewer::removeGraph(std::string name){
     _plot_elements.erase(name);
 }
 
-void Analog_Viewer::_element_apply_lintrans(std::string name){
+void Analog_Viewer::_elementApplyLintrans(std::string name){
     if (_plot_elements.find(name) == _plot_elements.end()) {
         std::cout << "Plot element named " << name << " does not exist" << std::endl;
         return;
@@ -116,7 +118,7 @@ void Analog_Viewer::ElementSetLintrans(){
     if (!name.empty()) {
         _plot_elements[name].mult = ui->ymult_dspinbox->value();
         _plot_elements[name].add = ui->yoffset_dspinbox->value();
-        _element_apply_lintrans(name);
+        _elementApplyLintrans(name);
         ui->plot->redrawPlot();
     }
 }
@@ -125,4 +127,12 @@ void Analog_Viewer::ResetLineEditor(){
     std::string name = ui->linechoose_cbox->currentText().toStdString();
     ui->ymult_dspinbox->setValue(_plot_elements[name].mult);
     ui->yoffset_dspinbox->setValue(_plot_elements[name].add);
+}
+
+void Analog_Viewer::_setZoom(int i){
+    ui->plot->zoom(i - ui->xwidth_dspinbox->value()/2, i + ui->xwidth_dspinbox->value()/2, -10, 10);
+}
+
+void Analog_Viewer::SetZoom(int i){
+    _setZoom(i);
 }

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -6,15 +6,21 @@
 #define WHISKERTOOLBOX_ANALOG_VIEWER_HPP
 
 #include <QWidget>
+#include <QMainWindow>
+
+#include "Media_Window.hpp"
+#include "TimeScrollBar/TimeScrollBar.hpp"
+#include "DataManager.hpp"
 
 namespace Ui {
 class Analog_Viewer;
 }
 
-class Analog_Viewer : public QWidget {
+class Analog_Viewer : public QMainWindow {
     Q_OBJECT
 public:
-    Analog_Viewer(QWidget *parent = 0);
+
+    Analog_Viewer(Media_Window* scene, std::shared_ptr<DataManager> data_manager, TimeScrollBar* time_scrollbar, QWidget *parent = 0);
     ~Analog_Viewer();
 
     void openWidget();
@@ -24,8 +30,15 @@ protected:
     //void keyPressEvent(QKeyEvent *event);
 
 private:
+    Media_Window * _scene;
+    std::shared_ptr<DataManager> _data_manager;
+    TimeScrollBar* _time_scrollbar;
 
     Ui::Analog_Viewer *ui;
+
+public slots:
+    void SetFrame(int i);
+
 private slots:
 
 };

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -27,7 +27,7 @@ public:
 
     void openWidget();
 
-    void plotLine(std::string name, std::vector<double>& data);
+    void plotLine(std::string name);
     void removeGraph(std::string name);
 
 protected:
@@ -41,14 +41,23 @@ private:
 
     Ui::Analog_Viewer *ui;
 
-    std::map<std::string, JKQTPPlotElement*> _plot_elements;
+    struct PlotElementInfo {
+        double mult = 1.0;
+        double add = 0.0;
+        JKQTPPlotElement* element = nullptr;
+        size_t ds_y_col;
 
+        PlotElementInfo() {}
+    };
+    std::map<std::string, PlotElementInfo> _plot_elements;
 
+    void _element_apply_lintrans(std::string name);
 public slots:
     void SetFrame(int i);
 
 private slots:
-
+    void ElementSetLintrans();
+    void ResetLineEditor();
 };
 
 

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -8,6 +8,8 @@
 #include <QWidget>
 #include <QMainWindow>
 
+#include "jkqtplotter/jkqtplotter.h"
+
 #include "Media_Window.hpp"
 #include "TimeScrollBar/TimeScrollBar.hpp"
 #include "DataManager.hpp"
@@ -25,6 +27,9 @@ public:
 
     void openWidget();
 
+    void plotLine(std::string name, std::vector<double>& data);
+    void removeGraph(std::string name);
+
 protected:
     //void closeEvent(QCloseEvent *event);
     //void keyPressEvent(QKeyEvent *event);
@@ -35,6 +40,9 @@ private:
     TimeScrollBar* _time_scrollbar;
 
     Ui::Analog_Viewer *ui;
+
+    std::map<std::string, JKQTPPlotElement*> _plot_elements;
+
 
 public slots:
     void SetFrame(int i);

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -51,13 +51,16 @@ private:
     };
     std::map<std::string, PlotElementInfo> _plot_elements;
 
-    void _element_apply_lintrans(std::string name);
+    void _setZoom(int i);
+
+    void _elementApplyLintrans(std::string name);
 public slots:
     void SetFrame(int i);
 
 private slots:
     void ElementSetLintrans();
     void ResetLineEditor();
+    void SetZoom(int i);
 };
 
 

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -51,16 +51,18 @@ private:
     };
     std::map<std::string, PlotElementInfo> _plot_elements;
 
-    void _setZoom(int i);
+    void _setZoom();
 
     void _elementApplyLintrans(std::string name);
+
+    int64_t _current_frame = 0;
 public slots:
     void SetFrame(int i);
 
 private slots:
     void ElementSetLintrans();
     void ResetLineEditor();
-    void SetZoom(int i);
+    void SetZoom();
 };
 
 

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
@@ -136,7 +136,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>X axes width:</string>
+    <string>X axis width:</string>
    </property>
   </widget>
   <widget class="QDoubleSpinBox" name="xwidth_dspinbox">
@@ -156,6 +156,9 @@
    </property>
    <property name="maximum">
     <double>100000.000000000000000</double>
+   </property>
+   <property name="singleStep">
+    <double>0.010000000000000</double>
    </property>
    <property name="value">
     <double>10.000000000000000</double>

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
@@ -6,14 +6,32 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>453</width>
+    <height>341</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <widget class="JKQTPlotter" name="plot" native="true">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>50</y>
+     <width>431</width>
+     <height>281</height>
+    </rect>
+   </property>
+  </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>JKQTPlotter</class>
+   <extends>QWidget</extends>
+   <header>jkqtplotter/jkqtplotter.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
@@ -126,6 +126,41 @@
     </property>
    </widget>
   </widget>
+  <widget class="QLabel" name="label_4">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>440</y>
+     <width>81</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>X axes width:</string>
+   </property>
+  </widget>
+  <widget class="QDoubleSpinBox" name="xwidth_dspinbox">
+   <property name="geometry">
+    <rect>
+     <x>110</x>
+     <y>441</y>
+     <width>121</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="decimals">
+    <number>5</number>
+   </property>
+   <property name="minimum">
+    <double>0.000010000000000</double>
+   </property>
+   <property name="maximum">
+    <double>100000.000000000000000</double>
+   </property>
+   <property name="value">
+    <double>10.000000000000000</double>
+   </property>
+  </widget>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>453</width>
-    <height>341</height>
+    <width>472</width>
+    <height>543</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,11 +17,114 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>50</y>
-     <width>431</width>
+     <y>10</y>
+     <width>451</width>
      <height>281</height>
     </rect>
    </property>
+  </widget>
+  <widget class="QGroupBox" name="groupBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>320</y>
+     <width>451</width>
+     <height>111</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Edit Line</string>
+   </property>
+   <widget class="QComboBox" name="linechoose_cbox">
+    <property name="geometry">
+     <rect>
+      <x>80</x>
+      <y>20</y>
+      <width>280</width>
+      <height>41</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>30</y>
+      <width>81</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Line to edit:</string>
+    </property>
+   </widget>
+   <widget class="QDoubleSpinBox" name="ymult_dspinbox">
+    <property name="geometry">
+     <rect>
+      <x>90</x>
+      <y>60</y>
+      <width>91</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <double>-99999.000000000000000</double>
+    </property>
+    <property name="maximum">
+     <double>99999.000000000000000</double>
+    </property>
+    <property name="singleStep">
+     <double>0.010000000000000</double>
+    </property>
+    <property name="value">
+     <double>1.000000000000000</double>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_2">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>60</y>
+      <width>91</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Y multiplier:</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_3">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>80</y>
+      <width>58</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Y offset:</string>
+    </property>
+   </widget>
+   <widget class="QDoubleSpinBox" name="yoffset_dspinbox">
+    <property name="geometry">
+     <rect>
+      <x>90</x>
+      <y>80</y>
+      <width>91</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <double>-99999.000000000000000</double>
+    </property>
+    <property name="maximum">
+     <double>99999.000000000000000</double>
+    </property>
+    <property name="singleStep">
+     <double>0.100000000000000</double>
+    </property>
+   </widget>
   </widget>
  </widget>
  <customwidgets>

--- a/src/WhiskerToolbox/CMakeLists.txt
+++ b/src/WhiskerToolbox/CMakeLists.txt
@@ -10,8 +10,6 @@ qt_standard_project_setup()
 
 add_subdirectory(DataManager)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -v")
-
 set(PROJECT_SOURCES
         main.cpp
         whiskertoolbox.qrc

--- a/src/WhiskerToolbox/Main_Window/mainwindow.cpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.cpp
@@ -192,10 +192,11 @@ void MainWindow::openAnalogViewer()
         registerDockWidget(key, analogViewer.get(), ads::CenterDockWidgetArea);
         _widgets[key] = std::move(analogViewer);
 
-        connect(ui->time_scrollbar, &TimeScrollBar::timeChanged, static_cast<Analog_Viewer*>(_widgets[key].get()), &Analog_Viewer::SetFrame);
+        connect(ui->time_scrollbar, &TimeScrollBar::timeChanged, dynamic_cast<Analog_Viewer*>(_widgets[key].get()), &Analog_Viewer::SetFrame);
     }
 
-    dynamic_cast<Analog_Viewer*>(_widgets[key].get())->openWidget();
+    auto ptr = dynamic_cast<Analog_Viewer*>(_widgets[key].get());
+    ptr->openWidget();
 
 
     showDockWidget(key);

--- a/src/WhiskerToolbox/Main_Window/mainwindow.cpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.cpp
@@ -64,6 +64,8 @@ void MainWindow::_createActions()
     connect(ui->actionAnalog_Viewer, &QAction::triggered, this, &MainWindow::openAnalogViewer);
     connect(ui->actionImage_Processing, &QAction::triggered, this, &MainWindow::openImageProcessing);
     connect(ui->actionTongue_Tracking, &QAction::triggered, this, &MainWindow::openTongueTracking);
+
+    connect(ui->time_scrollbar, &TimeScrollBar::timeChanged, _scene, &Media_Window::LoadFrame);
 }
 
 /*
@@ -185,13 +187,17 @@ void MainWindow::openAnalogViewer()
     std::string const key = "analog_viewer";
 
     if (_widgets.find(key) == _widgets.end()) {
-        auto analogViewer = std::make_unique<Analog_Viewer>();
+        auto analogViewer = std::make_unique<Analog_Viewer>(_scene, _data_manager, ui->time_scrollbar, this);
         analogViewer->setObjectName(key);
         registerDockWidget(key, analogViewer.get(), ads::CenterDockWidgetArea);
         _widgets[key] = std::move(analogViewer);
+
+        connect(ui->time_scrollbar, &TimeScrollBar::timeChanged, static_cast<Analog_Viewer*>(_widgets[key].get()), &Analog_Viewer::SetFrame);
     }
 
     dynamic_cast<Analog_Viewer*>(_widgets[key].get())->openWidget();
+
+
     showDockWidget(key);
 }
 

--- a/src/WhiskerToolbox/Main_Window/mainwindow.cpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.cpp
@@ -143,6 +143,10 @@ void MainWindow::_loadTimeSeriesCSV()
 
     std::cout << "Loaded series " << key << " with " <<
         _data_manager->getAnalogTimeSeries(key)->getAnalogTimeSeries().size() << " points " << std::endl;
+
+    if (_widgets.find("analog_viewer") != _widgets.end()) {
+        dynamic_cast<Analog_Viewer*>(_widgets["analog_viewer"].get())->plotLine(key);
+    }
 }
 
 void MainWindow::_LoadData(std::string filepath) {
@@ -227,7 +231,6 @@ void MainWindow::openAnalogViewer()
 
     auto ptr = dynamic_cast<Analog_Viewer*>(_widgets[key].get());
     ptr->openWidget();
-
 
     showDockWidget(key);
 }


### PR DESCRIPTION
Line plot display:
- Original vector of data is kept in the data manager
- To make a line plot the data needs to be copied into the JKQTPlotter DataStore. While doing so a linear transform (`data[i]*mult + offset`) is performed to support y "zoom" and offset. 
    - These can be adjusted through the analog viewer GUI on a per line plot basis