### PR TITLE
Adding Digital Time Series

### DIFF
--- a/src/WhiskerToolbox/AnalogViewer/DigitalTimeSeriesGraph.cpp
+++ b/src/WhiskerToolbox/AnalogViewer/DigitalTimeSeriesGraph.cpp
@@ -1,0 +1,90 @@
+#include "DigitalTimeSeriesGraph.hpp"
+
+#include "jkqtplotter/jkqtplotter.h"
+#include "jkqtplotter/graphs/jkqtprange.h"
+
+DigitalTimeSeriesGraph::DigitalTimeSeriesGraph(JKQTBasePlotter *parent):
+    JKQTPPlotElement(parent)
+{
+    _parent = parent;
+}
+
+void DigitalTimeSeriesGraph::load_digital_vector(std::vector<std::pair<float, float>> digital_vector){
+    bool first = false;
+    QColor color;
+    for (auto [start, end] : digital_vector){
+        JKQTPVerticalRange* graph = new JKQTPVerticalRange(_parent);
+        graph->setPlotCenterLine(false);
+        if (!first){
+            color = graph->getFillColor();
+            color.setAlpha(100);
+            first = true;
+        }
+        graph->setColor(color);
+        graph->setRangeMax(end);
+        graph->setRangeMin(start);
+        _graphs.push_back(graph);
+    }
+}
+
+void DigitalTimeSeriesGraph::draw(JKQTPEnhancedPainter &painter)
+{   
+    for (auto graph : _graphs){
+        graph->draw(painter);
+    }
+}
+
+void DigitalTimeSeriesGraph::drawKeyMarker(JKQTPEnhancedPainter& painter, const QRectF& rect){
+    for (auto graph : _graphs){
+        graph->drawKeyMarker(painter, rect);
+    }
+}
+
+bool DigitalTimeSeriesGraph::getXMinMax(double& minx, double& maxx, double& smallestGreaterZero){
+    if (_graphs.empty()){
+        return false;
+    }
+
+    double mn = 1e9;
+    double mx = -1e9;
+    double mn_gz = 1e9;
+    for (auto graph : _graphs){
+        double cur_mn, cur_mx, cur_mn_gz;
+        graph->getXMinMax(cur_mn, cur_mx, cur_mn_gz);
+
+        mn = std::min(mn, cur_mn);
+        mx = std::max(mx, cur_mx);
+        mn_gz = std::min(mn_gz, cur_mn_gz);
+    }
+    minx = mn;
+    maxx = mx;
+    smallestGreaterZero = mn_gz;
+    return true;
+}
+
+bool DigitalTimeSeriesGraph::getYMinMax(double& miny, double& maxy, double& smallestGreaterZero){
+    if (_graphs.empty()){
+        return false;
+    }
+
+    double mn = 1e9;
+    double mx = -1e9;
+    double mn_gz = 1e9;
+    for (auto graph : _graphs){
+        double cur_mn, cur_mx, cur_mn_gz;
+        graph->getYMinMax(cur_mn, cur_mx, cur_mn_gz);
+
+        mn = std::min(mn, cur_mn);
+        mx = std::max(mx, cur_mx);
+        mn_gz = std::min(mn_gz, cur_mn_gz);
+    }
+    miny = mn;
+    maxy = mx;
+    smallestGreaterZero = mn_gz;
+    return true;
+}
+
+QColor DigitalTimeSeriesGraph::getKeyLabelColor() const{
+    // i dont know what this is for
+    return QColor(0, 255, 0);
+}

--- a/src/WhiskerToolbox/AnalogViewer/DigitalTimeSeriesGraph.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/DigitalTimeSeriesGraph.hpp
@@ -1,0 +1,31 @@
+#ifndef DIGITAL_TIME_SERIES_GRAPH_HPP
+#define DIGITAL_TIME_SERIES_GRAPH_HPP
+
+#include <vector>
+
+#include "jkqtplotter/jkqtplotter.h"
+#include "jkqtplotter/graphs/jkqtprange.h"
+
+class DigitalTimeSeriesGraph : public JKQTPPlotElement {
+    
+public:
+    DigitalTimeSeriesGraph(JKQTBasePlotter *parent=nullptr);
+
+
+    void load_digital_vector(std::vector<std::pair<float, float>> digital_vector);
+
+
+    void draw(JKQTPEnhancedPainter& painter) override;
+    void drawKeyMarker(JKQTPEnhancedPainter& painter, const QRectF& rect) override;
+    bool getXMinMax(double& minx, double& maxx, double& smallestGreaterZero) override;
+    bool getYMinMax(double& miny, double& maxy, double& smallestGreaterZero) override;
+    QColor getKeyLabelColor() const override;
+
+
+private:
+    std::vector<JKQTPVerticalRange*> _graphs;
+
+    JKQTBasePlotter* _parent;
+};
+
+#endif

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
@@ -28,6 +28,7 @@ Analog_Viewer::Analog_Viewer(Media_Window *scene, std::shared_ptr<DataManager> d
     connect(ui->yoffset_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::ElementSetLintrans);
     connect(ui->xwidth_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::SetZoom);
     connect(ui->show_checkbox, &QCheckBox::stateChanged, this, &Analog_Viewer::ElementSetShow);
+    connect(ui->plot, &JKQTPlotter::plotMouseClicked, this, &Analog_Viewer::ClickEvent);
 }
 
 Analog_Viewer::~Analog_Viewer() {
@@ -44,6 +45,9 @@ void Analog_Viewer::openWidget()
     _setZoom();
 
     ui->plot->setContextMenuMode(jkqtpcmmNoContextMenu);
+    ui->plot->clearAllRegisteredMouseDoubleClickActions();
+    ui->plot->registerMouseDragAction(Qt::LeftButton, Qt::NoModifier, jkqtpmdaPanPlotOnMove);
+
     this->show();
 }
 
@@ -158,6 +162,21 @@ void Analog_Viewer::ElementSetShow(){
     }
 }
 
+void Analog_Viewer::ClickEvent(double x, double y, Qt::KeyboardModifiers modifiers, Qt::MouseButton button){
+    if (button == Qt::LeftButton) {
+        double min_dist = 1e9;
+        std::string min_dist_name = "";
+        for (auto& [name, graphInfo] : _graphs) {
+            if (graphInfo.show){
+                double dist = graphInfo.graph->hitTest(QPointF(x, y));
+                if (dist < min_dist) {
+                    min_dist = dist;
+                    min_dist_name = name;
+                }
+            }
+        }
+        if (!min_dist_name.empty()) {
+            ui->graphchoose_cbox->setCurrentText(QString::fromStdString(min_dist_name));
         }
     }
 }

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.cpp
@@ -27,6 +27,7 @@ Analog_Viewer::Analog_Viewer(Media_Window *scene, std::shared_ptr<DataManager> d
     connect(ui->ymult_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::ElementSetLintrans);
     connect(ui->yoffset_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::ElementSetLintrans);
     connect(ui->xwidth_dspinbox, &QDoubleSpinBox::valueChanged, this, &Analog_Viewer::SetZoom);
+    connect(ui->show_checkbox, &QCheckBox::stateChanged, this, &Analog_Viewer::ElementSetShow);
 }
 
 Analog_Viewer::~Analog_Viewer() {
@@ -42,6 +43,7 @@ void Analog_Viewer::openWidget()
     }
     _setZoom();
 
+    ui->plot->setContextMenuMode(jkqtpcmmNoContextMenu);
     this->show();
 }
 
@@ -127,6 +129,12 @@ void Analog_Viewer::ElementSetLintrans(){
 }
 
 void Analog_Viewer::SetPlotEditor(){
+    std::string name = ui->graphchoose_cbox->currentText().toStdString();
+    ui->ymult_dspinbox->setValue(_graphs[name].mult);
+    ui->yoffset_dspinbox->setValue(_graphs[name].add);
+    ui->show_checkbox->setChecked(_graphs[name].show);
+    if (!_prev_element.empty()) {
+        _graphs[_prev_element].graph->setHighlighted(false);
     }
     _graphs[name].graph->setHighlighted(true);
     _prev_element = name;
@@ -140,6 +148,16 @@ void Analog_Viewer::_setZoom(){
 void Analog_Viewer::SetZoom(){
     _setZoom();
 }
+
+void Analog_Viewer::ElementSetShow(){
+    std::string name = ui->graphchoose_cbox->currentText().toStdString();
+    if (!name.empty()) {
+        _graphs[name].show = ui->show_checkbox->isChecked();
+        _graphs[name].graph->setVisible(_graphs[name].show);
+        ui->plot->redrawPlot();
+    }
+}
+
         }
     }
 }

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -67,6 +67,7 @@ private slots:
     void ElementSetShow();
     void SetPlotEditor();
     void SetZoom();
+    void ClickEvent(double x, double y, Qt::KeyboardModifiers modifiers, Qt::MouseButton button);
 };
 
 

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -41,19 +41,22 @@ private:
 
     Ui::Analog_Viewer *ui;
 
-    struct PlotElementInfo {
+    struct GraphInfo {
         double mult = 1.0;
         double add = 0.0;
-        JKQTPPlotElement* element = nullptr;
+        JKQTPPlotElement* graph = nullptr;
+        bool show = true;
         size_t ds_y_col;
 
-        PlotElementInfo() {}
+        GraphInfo() {}
     };
-    std::map<std::string, PlotElementInfo> _plot_elements;
+    std::map<std::string, GraphInfo> _graphs;
 
     void _setZoom();
 
     void _elementApplyLintrans(std::string name);
+
+    std::string _prev_element = ""; 
 
     int64_t _current_frame = 0;
 public slots:
@@ -61,7 +64,7 @@ public slots:
 
 private slots:
     void ElementSetLintrans();
-    void ResetLineEditor();
+    void SetPlotEditor();
     void SetZoom();
 };
 

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -27,7 +27,8 @@ public:
 
     void openWidget();
 
-    void plotLine(std::string name);
+    void plotAnalog(std::string name);
+    void plotDigital(std::string name);
     void removeGraph(std::string name);
 
 protected:
@@ -54,17 +55,17 @@ private:
 
     void _setZoom();
 
-    void _elementApplyLintrans(std::string name);
+    void _graphApplyLintrans(std::string name);
 
-    std::string _prev_element = ""; 
+    std::string _prev_analog = ""; 
 
     int64_t _current_frame = 0;
 public slots:
     void SetFrame(int i);
 
 private slots:
-    void ElementSetLintrans();
-    void ElementSetShow();
+    void GraphSetLintrans();
+    void GraphSetShow();
     void SetPlotEditor();
     void SetZoom();
     void ClickEvent(double x, double y, Qt::KeyboardModifiers modifiers, Qt::MouseButton button);

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -64,6 +64,7 @@ public slots:
 
 private slots:
     void ElementSetLintrans();
+    void ElementSetShow();
     void SetPlotEditor();
     void SetZoom();
 };

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.hpp
@@ -42,12 +42,17 @@ private:
 
     Ui::Analog_Viewer *ui;
 
+    enum class GraphType {
+        analog,
+        digital
+    };
     struct GraphInfo {
         double mult = 1.0;
         double add = 0.0;
-        JKQTPPlotElement* graph = nullptr;
+        JKQTPPlotElement* graph;
         bool show = true;
         size_t ds_y_col;
+        GraphType type;
 
         GraphInfo() {}
     };
@@ -60,6 +65,8 @@ private:
     std::string _prev_analog = ""; 
 
     int64_t _current_frame = 0;
+
+    std::string get_selected_graph_name();
 public slots:
     void SetFrame(int i);
 

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
@@ -125,6 +125,19 @@
      <double>0.100000000000000</double>
     </property>
    </widget>
+   <widget class="QCheckBox" name="show_checkbox">
+    <property name="geometry">
+     <rect>
+      <x>230</x>
+      <y>60</y>
+      <width>85</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Show</string>
+    </property>
+   </widget>
   </widget>
   <widget class="QLabel" name="label_4">
    <property name="geometry">

--- a/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
+++ b/src/WhiskerToolbox/AnalogViewer/analog_viewer.ui
@@ -33,12 +33,12 @@
     </rect>
    </property>
    <property name="title">
-    <string>Edit Line</string>
+    <string>Graph Editor</string>
    </property>
-   <widget class="QComboBox" name="linechoose_cbox">
+   <widget class="QComboBox" name="graphchoose_cbox">
     <property name="geometry">
      <rect>
-      <x>80</x>
+      <x>120</x>
       <y>20</y>
       <width>280</width>
       <height>41</height>
@@ -50,12 +50,12 @@
      <rect>
       <x>10</x>
       <y>30</y>
-      <width>81</width>
+      <width>111</width>
       <height>21</height>
      </rect>
     </property>
     <property name="text">
-     <string>Line to edit:</string>
+     <string>Graph of Interest:</string>
     </property>
    </widget>
    <widget class="QDoubleSpinBox" name="ymult_dspinbox">

--- a/src/WhiskerToolbox/CMakeLists.txt
+++ b/src/WhiskerToolbox/CMakeLists.txt
@@ -18,6 +18,8 @@ set(PROJECT_SOURCES
         AnalogViewer/analog_viewer.hpp
         AnalogViewer/analog_viewer.cpp
         AnalogViewer/analog_viewer.ui
+        AnalogViewer/DigitalTimeSeriesGraph.cpp
+        AnalogViewer/DigitalTimeSeriesGraph.hpp
 
         Main_Window/mainwindow.cpp
         Main_Window/mainwindow.hpp

--- a/src/WhiskerToolbox/DataManager/AnalogTimeSeries/Analog_Time_Series.cpp
+++ b/src/WhiskerToolbox/DataManager/AnalogTimeSeries/Analog_Time_Series.cpp
@@ -15,7 +15,7 @@ std::vector<float> const & AnalogTimeSeries::getAnalogTimeSeries() const
     return _data;
 }
 
-std::vector<float> load_series_from_csv(std::string const& filename)
+std::vector<float> load_analog_series_from_csv(std::string const& filename)
 {
 
     std::string csv_line;

--- a/src/WhiskerToolbox/DataManager/AnalogTimeSeries/Analog_Time_Series.hpp
+++ b/src/WhiskerToolbox/DataManager/AnalogTimeSeries/Analog_Time_Series.hpp
@@ -18,6 +18,6 @@ private:
     std::vector<float> _data {};
 };
 
-std::vector<float> load_series_from_csv(std::string const& filename);
+std::vector<float> load_analog_series_from_csv(std::string const& filename);
 
 #endif // ANALOG_TIME_SERIES_HPP

--- a/src/WhiskerToolbox/DataManager/CMakeLists.txt
+++ b/src/WhiskerToolbox/DataManager/CMakeLists.txt
@@ -27,6 +27,9 @@ add_library(DataManager SHARED
         AnalogTimeSeries/Analog_Time_Series.hpp
         AnalogTimeSeries/Analog_Time_Series.cpp
 
+        DigitalTimeSeries/Digital_Time_Series.hpp
+        DigitalTimeSeries/Digital_Time_Series.cpp
+
         utils/container.hpp
         utils/hdf5_mask_load.hpp
         utils/opencv_utility.hpp

--- a/src/WhiskerToolbox/DataManager/DataManager.cpp
+++ b/src/WhiskerToolbox/DataManager/DataManager.cpp
@@ -114,6 +114,21 @@ std::vector<std::string> DataManager::getAnalogTimeSeriesKeys()
     return get_keys(_analog);
 }
 
+void DataManager::createDigitalTimeSeries(std::string const & digital_key)
+{
+    _digital[digital_key] = std::make_shared<DigitalTimeSeries>();
+}
+
+std::shared_ptr<DigitalTimeSeries> DataManager::getDigitalTimeSeries(std::string const & digital_key)
+{
+    return _digital[digital_key];
+}
+
+std::vector<std::string> DataManager::getDigitalTimeSeriesKeys()
+{
+    return get_keys(_digital);
+}
+
 std::vector<std::vector<float>> read_ragged_hdf5(std::string const & filepath, std::string const & key)
 {
     auto myvector = load_ragged_array<float>(filepath, key);

--- a/src/WhiskerToolbox/DataManager/DataManager.hpp
+++ b/src/WhiskerToolbox/DataManager/DataManager.hpp
@@ -5,6 +5,7 @@
 #include "Lines/Line_Data.hpp"
 #include "Masks/Mask_Data.hpp"
 #include "Points/Point_Data.hpp"
+#include "DigitalTimeSeries/Digital_Time_Series.hpp"
 
 #include <functional> // std::function
 #include <memory> // std::shared_ptr
@@ -46,6 +47,10 @@ public:
     std::shared_ptr<AnalogTimeSeries> getAnalogTimeSeries(std::string const & analog_key);
     std::vector<std::string> getAnalogTimeSeriesKeys();
 
+    void createDigitalTimeSeries(std::string const & digital_key);
+    std::shared_ptr<DigitalTimeSeries> getDigitalTimeSeries(std::string const & digital_key);
+    std::vector<std::string> getDigitalTimeSeriesKeys();
+
     std::shared_ptr<TimeFrame> getTime() {return _time;};
 
     using ObserverCallback = std::function<void()>;
@@ -72,6 +77,8 @@ private:
     std::unordered_map<std::string, std::shared_ptr<MaskData>> _masks;
 
     std::unordered_map<std::string, std::shared_ptr<AnalogTimeSeries>> _analog;
+
+    std::unordered_map<std::string, std::shared_ptr<DigitalTimeSeries>> _digital;
 
     std::shared_ptr<TimeFrame> _time;
 

--- a/src/WhiskerToolbox/DataManager/DigitalTimeSeries/Digital_Time_Series.cpp
+++ b/src/WhiskerToolbox/DataManager/DigitalTimeSeries/Digital_Time_Series.cpp
@@ -1,0 +1,33 @@
+#include "Digital_Time_Series.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <utility>
+
+DigitalTimeSeries::DigitalTimeSeries(std::vector<std::pair<float, float>> digital_vector)
+{
+    _data = digital_vector;
+}
+
+std::vector<std::pair<float, float>> const & DigitalTimeSeries::getDigitalTimeSeries() const
+{
+    return _data;
+}
+
+std::vector<std::pair<float, float>> load_digital_series_from_csv(std::string const& filename){
+    std::string csv_line;
+
+    std::fstream myfile;
+    myfile.open (filename, std::fstream::in);
+
+    float start, end;
+    auto output = std::vector<std::pair<float, float>>();
+    while (getline(myfile, csv_line)) {
+        std::stringstream ss(csv_line);
+        ss >> start >> end;
+        output.emplace_back(start, end);
+    }
+
+    return output;
+}

--- a/src/WhiskerToolbox/DataManager/DigitalTimeSeries/Digital_Time_Series.hpp
+++ b/src/WhiskerToolbox/DataManager/DigitalTimeSeries/Digital_Time_Series.hpp
@@ -1,0 +1,23 @@
+#ifndef DIGITAL_TIME_SERIES_HPP
+#define DIGITAL_TIME_SERIES_HPP
+
+#include <string>
+#include <vector>
+#include <utility>
+
+class DigitalTimeSeries {
+public:
+    DigitalTimeSeries() = default;
+    DigitalTimeSeries(std::vector<std::pair<float, float>> digital_vector);
+
+    void setData(std::vector<std::pair<float, float>> digital_vector) { _data = digital_vector;};
+    std::vector<std::pair<float, float>> const& getDigitalTimeSeries() const;
+
+private:
+    std::vector<std::pair<float, float>> _data {};
+
+};
+
+std::vector<std::pair<float, float>> load_digital_series_from_csv(std::string const& filename);
+
+#endif // DIGITAL_TIME_SERIES_HPP

--- a/src/WhiskerToolbox/Grabcut_Widget/Grabcut_Widget.cpp
+++ b/src/WhiskerToolbox/Grabcut_Widget/Grabcut_Widget.cpp
@@ -55,6 +55,7 @@ void Grabcut_Widget::setup(cv::Mat img, int frame_index) {
     _updateDisplays();
     ui->editor_label->setPixmap(_img_disp_pixmap);
     ui->editor_label->setScaledContents(true);
+    ui->iter_pushbtn->setEnabled(false);
     _reset();
 }
 
@@ -179,6 +180,9 @@ void Grabcut_Widget::mouseReleaseEvent(QMouseEvent *event){
         QPoint p = _scaleTransMouse(event->pos());
         _tool.mouseUp(p.x(), p.y());
         _updateDisplays();
+        if (!_tool.getRectStage()){
+            ui->iter_pushbtn->setEnabled(true);
+        }
     }
 }
 

--- a/src/WhiskerToolbox/Main_Window/mainwindow.cpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.cpp
@@ -80,7 +80,8 @@ void MainWindow::_createActions()
 
     connect(ui->actionLoad_Images, &QAction::triggered,this, &MainWindow::Load_Images);
 
-    connect(ui->actionLoad_Time_Series_CSV, &QAction::triggered, this, &MainWindow::_loadTimeSeriesCSV);
+    connect(ui->actionLoad_Analog_Time_Series_CSV, &QAction::triggered, this, &MainWindow::_loadAnalogTimeSeriesCSV);
+    connect(ui->actionLoad_Digital_Time_Series_CSV, &QAction::triggered, this, &MainWindow::_loadDigitalTimeSeriesCSV);
 
     connect(ui->time_scrollbar, &TimeScrollBar::timeChanged, _scene, &Media_Window::LoadFrame);
 
@@ -137,7 +138,7 @@ void MainWindow::Load_Images() {
 
 }
 
-void MainWindow::_loadTimeSeriesCSV()
+void MainWindow::_loadAnalogTimeSeriesCSV()
 {
     auto filename =  QFileDialog::getOpenFileName(
         this,
@@ -162,7 +163,35 @@ void MainWindow::_loadTimeSeriesCSV()
         _data_manager->getAnalogTimeSeries(key)->getAnalogTimeSeries().size() << " points " << std::endl;
 
     if (_widgets.find("analog_viewer") != _widgets.end()) {
-        dynamic_cast<Analog_Viewer*>(_widgets["analog_viewer"].get())->plotLine(key);
+        dynamic_cast<Analog_Viewer*>(_widgets["analog_viewer"].get())->plotAnalog(key);
+    }
+}
+
+void MainWindow::_loadDigitalTimeSeriesCSV(){
+    auto filename =  QFileDialog::getOpenFileName(
+        this,
+        "Load Video File",
+        QDir::currentPath(),
+        "All files (*.*) ;; CSV (*.csv)");
+
+    if (filename.isNull()) {
+        return;
+    }
+
+    auto series = load_digital_series_from_csv(filename.toStdString());
+
+    auto path = std::filesystem::path(filename.toStdString());
+    auto key = path.filename().replace_extension("").string();
+
+    _data_manager->createDigitalTimeSeries(key);
+
+    _data_manager->getDigitalTimeSeries(key)->setData(series);
+
+    std::cout << "Loaded series " << key << " with " <<
+        _data_manager->getDigitalTimeSeries(key)->getDigitalTimeSeries().size() << " points " << std::endl;
+
+    if (_widgets.find("analog_viewer") != _widgets.end()) {
+        dynamic_cast<Analog_Viewer*>(_widgets["analog_viewer"].get())->plotDigital(key);
     }
 }
 

--- a/src/WhiskerToolbox/Main_Window/mainwindow.cpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.cpp
@@ -149,7 +149,7 @@ void MainWindow::_loadTimeSeriesCSV()
         return;
     }
 
-    auto series = load_series_from_csv(filename.toStdString());
+    auto series = load_analog_series_from_csv(filename.toStdString());
 
     auto path = std::filesystem::path(filename.toStdString());
     auto key = path.filename().replace_extension("").string();

--- a/src/WhiskerToolbox/Main_Window/mainwindow.hpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.hpp
@@ -63,7 +63,8 @@ private slots:
     void Load_Video();
     void Load_Images();
 
-    void _loadTimeSeriesCSV();
+    void _loadAnalogTimeSeriesCSV();
+    void _loadDigitalTimeSeriesCSV();
 
     void openWhiskerTracking();
     void openLabelMaker();

--- a/src/WhiskerToolbox/Main_Window/mainwindow.ui
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.ui
@@ -44,7 +44,7 @@
      <x>0</x>
      <y>0</y>
      <width>1191</width>
-     <height>22</height>
+     <height>36</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -54,7 +54,8 @@
     <addaction name="actionLoad_Video"/>
     <addaction name="actionLoad_Images"/>
     <addaction name="separator"/>
-    <addaction name="actionLoad_Time_Series_CSV"/>
+    <addaction name="actionLoad_Analog_Time_Series_CSV"/>
+    <addaction name="actionLoad_Digital_Time_Series_CSV"/>
    </widget>
    <widget class="QMenu" name="menuEdit">
     <property name="title">
@@ -123,9 +124,14 @@
     <string>Tongue Tracking</string>
    </property>
   </action>
-  <action name="actionLoad_Time_Series_CSV">
+  <action name="actionLoad_Analog_Time_Series_CSV">
    <property name="text">
-    <string>Load Time Series (CSV)</string>
+    <string>Load Analog Time Series (CSV)</string>
+   </property>
+  </action>
+  <action name="actionLoad_Digital_Time_Series_CSV">
+   <property name="text">
+    <string>Load Digital Time Series (CSV)</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Other changes:
- Changing some naming to differentiate between analog/digital
- Changing some naming in order to be consistent with JKQTPlotter terminology
    - So a "plot" is what the user sees, i.e. the rectangular region with things inside
    - A "graph" is a single element within that region. Currently there are Analog graphs and digital graphs.
- Add a click to select graph feature (currently only works with the analog graphs since expected behavior might be ambiguous if digital graphs were included)
- Add hide show button for graphs
- Fix to disable grabcut iteration button before the rectangle is drawn.