### PR TITLE
Loading CSV keypoints in DLC fomat

### DIFF
--- a/src/WhiskerToolbox/DataManager/Points/Point_Data.cpp
+++ b/src/WhiskerToolbox/DataManager/Points/Point_Data.cpp
@@ -1,6 +1,7 @@
 
 #include "Point_Data.hpp"
 #include "utils/container.hpp"
+#include "utils/string_manip.hpp"
 
 #include <algorithm>
 #include <fstream>
@@ -91,4 +92,62 @@ std::map<int,Point2D<float>> load_points_from_csv(std::string const& filename, i
     std::cout.flush();
 
     return line_output;
+}
+
+std::map<std::string, std::map<int, Point2D<float>>> load_multiple_points_from_csv(std::string const& filename, int const frame_column){
+    std::fstream file;
+    file.open(filename, std::fstream::in);
+
+    std::string ln, ele;
+
+    getline(file, ln); // skip the "scorer" row
+    
+    getline(file, ln); // bodyparts row
+    std::vector<std::string> bodyparts;
+    {
+        std::stringstream ss(ln);
+        while (getline(ss, ele, ',')){
+            bodyparts.push_back(ele);
+        }
+    }
+
+    getline(file, ln); // coords row
+    std::vector<std::string> dims;
+    {
+        std::stringstream ss(ln);
+        while (getline(ss, ele, ',')){
+            dims.push_back(ele);
+        }
+    }
+
+    std::map<std::string, std::map<int, Point2D<float>>> data;
+    while (getline(file, ln)){
+        std::stringstream ss(ln);
+        int col_no = 0;
+        int frame_no = -1;
+        while (getline(ss, ele, ',')){
+            if (col_no == frame_column){
+                frame_no = std::stoi(extract_numbers_from_string(ele));
+            } else if (dims[col_no] == "x"){
+                data[bodyparts[col_no]][frame_no].x = std::stof(ele);
+            } else if (dims[col_no] == "y"){
+                data[bodyparts[col_no]][frame_no].y = std::stof(ele);
+            }
+            ++col_no;
+        }
+    }
+
+    // print data
+    for (auto const& [bp, frames] : data){
+        std::cout << bp << std::endl;
+        int i=0;
+        for (auto const& [frame, pos] : frames){
+            std::cout << frame << ": " << pos.x << ", " << pos.y << std::endl;
+            if (++i > 10){
+                break;
+            }
+        }
+    }
+
+    return data;
 }

--- a/src/WhiskerToolbox/DataManager/Points/Point_Data.cpp
+++ b/src/WhiskerToolbox/DataManager/Points/Point_Data.cpp
@@ -137,17 +137,5 @@ std::map<std::string, std::map<int, Point2D<float>>> load_multiple_points_from_c
         }
     }
 
-    // print data
-    for (auto const& [bp, frames] : data){
-        std::cout << bp << std::endl;
-        int i=0;
-        for (auto const& [frame, pos] : frames){
-            std::cout << frame << ": " << pos.x << ", " << pos.y << std::endl;
-            if (++i > 10){
-                break;
-            }
-        }
-    }
-
     return data;
 }

--- a/src/WhiskerToolbox/DataManager/Points/Point_Data.hpp
+++ b/src/WhiskerToolbox/DataManager/Points/Point_Data.hpp
@@ -39,6 +39,6 @@ private:
 };
 
 std::map<int,Point2D<float>> load_points_from_csv(std::string const& filename, int const frame_column, int const x_column, int const y_column);
-
+std::map<std::string, std::map<int, Point2D<float>>> load_multiple_points_from_csv(std::string const& filename, int const frame_column);
 
 #endif // POINT_DATA_HPP

--- a/src/WhiskerToolbox/Main_Window/mainwindow.cpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.cpp
@@ -35,9 +35,6 @@ MainWindow::MainWindow(QWidget *parent)
 {
     ui->setupUi(this);
 
-
-    load_multiple_points_from_csv("/Users/eric/Downloads/m3v1mp4DLC_resnet50_Eric's projectAug7shuffle1_500_filtered.csv", 0);
-
     _m_DockManager = new ads::CDockManager(this);
 
     //This is necessary to accept keyboard events

--- a/src/WhiskerToolbox/Main_Window/mainwindow.cpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.cpp
@@ -15,6 +15,8 @@
 #include "Tongue_Widget/Tongue_Widget.hpp"
 #include "Whisker_Widget.hpp"
 
+#include "Points/Point_Data.hpp"
+
 #include <QFileDialog>
 #include <QImage>
 #include <QKeyEvent>
@@ -32,6 +34,9 @@ MainWindow::MainWindow(QWidget *parent)
 
 {
     ui->setupUi(this);
+
+
+    load_multiple_points_from_csv("/Users/eric/Downloads/m3v1mp4DLC_resnet50_Eric's projectAug7shuffle1_500_filtered.csv", 0);
 
     _m_DockManager = new ads::CDockManager(this);
 


### PR DESCRIPTION
Relevant issue #34 

Similar to `load_points_from_csv`

Return: map of mapped frames/points, e.g.:
<img width="162" alt="Screenshot 2024-08-16 at 3 57 03 PM" src="https://github.com/user-attachments/assets/c7f37f75-fba0-4b28-830e-57cbf0571290">

Notes:
There's no way in the GUI to use this

The frame number column is still manually specified since I saw it varied between the two types of output I sent in the email. But determining x/y and the associated body part is done through the header information.

I wasn't sure what to do with the scorer row so I ignored it but it would also be simple to merge it into bodypart string or nest the map again and bucket the bodyparts by scorer.


