### PR TITLE
Data Transform UI Fixes

### DIFF
--- a/src/WhiskerToolbox/DataTransform_Widget/DataTransform_Widget.hpp
+++ b/src/WhiskerToolbox/DataTransform_Widget/DataTransform_Widget.hpp
@@ -65,6 +65,10 @@ private:
     QString _currentJsonFile;
     std::unique_ptr<TransformPipeline> _pipeline;
 
+    // Add these members to prevent unwanted scrolling
+    int _savedScrollPosition = 0;
+    bool _preventScrolling = false;
+
     void _initializeParameterWidgetFactories();
     void _displayParameterWidget(std::string const & op_name);
     

--- a/src/WhiskerToolbox/DataTransform_Widget/DataTransform_Widget.ui
+++ b/src/WhiskerToolbox/DataTransform_Widget/DataTransform_Widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>650</height>
+    <height>700</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,8 +18,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>250</width>
-    <height>600</height>
+    <width>350</width>
+    <height>700</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -40,7 +40,7 @@
      <x>0</x>
      <y>0</y>
      <width>398</width>
-     <height>648</height>
+     <height>698</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0,1,0">

--- a/src/WhiskerToolbox/Main_Window/mainwindow.cpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.cpp
@@ -613,8 +613,8 @@ void MainWindow::openDataTransforms() {
 
         dt_widget->setObjectName(key);
 
-        // Set explicit minimum size constraints
-        dt_widget->setMinimumSize(250, 400);
+        // Set explicit minimum size constraints - increased for better visibility
+        dt_widget->setMinimumSize(350, 700);
         dt_widget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
 
         // Create dock widget with appropriate settings


### PR DESCRIPTION
Increase minimum window size to prevent squishing.

Save scroll position and prevent auto scrolling.
