### PR TITLE
Fix squashed time scroll bar

### DIFF
--- a/src/WhiskerToolbox/Main_Window/mainwindow.cpp
+++ b/src/WhiskerToolbox/Main_Window/mainwindow.cpp
@@ -136,11 +136,11 @@ void MainWindow::_buildInitialLayout() {
     scrollbar_dock_widget->setFeature(ads::CDockWidget::DockWidgetDeleteOnClose, false);
     _m_DockManager->addDockWidget(ads::BottomDockWidgetArea, scrollbar_dock_widget, media_dockArea);
 
-    // Adjust splitter so scrollbar takes minimal space (e.g., 5%)
+    // Adjust splitter so scrollbar takes minimal space (e.g., 12%)
     auto * media_scrollbar_splitter = ads::internal::findParent<ads::CDockSplitter *>(_time_scrollbar);
     if (media_scrollbar_splitter) {
         int const height = media_scrollbar_splitter->height();
-        media_scrollbar_splitter->setSizes({height * 95 / 100, height * 5 / 100});
+        media_scrollbar_splitter->setSizes({height * 88 / 100, height * 12 / 100});
     }
 
     // Add the group management widget to the top right corner

--- a/src/WhiskerToolbox/TimeScrollBar/TimeScrollBar.ui
+++ b/src/WhiskerToolbox/TimeScrollBar/TimeScrollBar.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>654</width>
-    <height>129</height>
+    <height>103</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>650</width>
-    <height>75</height>
+    <height>85</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -162,28 +162,22 @@
            </property>
           </widget>
          </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Video Time:</string>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="time_label">
-           <property name="text">
-            <string>0</string>
+           <property name="sizeType">
+            <enum>QSizePolicy::Policy::Fixed</enum>
            </property>
-          </widget>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
          <item>
           <widget class="QLabel" name="label_5">
            <property name="text">
@@ -209,6 +203,50 @@
             <number>1</number>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Video Time:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="time_label">
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -241,19 +279,6 @@
       </spacer>
      </item>
     </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Scroll bar takes more space in the main window and has an increased min height. 

The arrowstepsize label and spinbox were moved 