### PR TITLE
Refactor AnalogEventThresholdParams options struct to use default initializers

### DIFF
--- a/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.cpp
+++ b/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.cpp
@@ -14,15 +14,9 @@ std::shared_ptr<DigitalEventSeries> analogEventThreshold(
     AnalogEventThresholdParams const& params,
     ComputeContext const& ctx) {
     
-    // Validate parameters
-    if (!params.isValidDirection()) {
-        std::cerr << "Invalid direction parameter: " << params.direction << std::endl;
-        return std::make_shared<DigitalEventSeries>();
-    }
-    
     float const threshold = params.threshold_value;
     float const lockout_time = params.lockout_time.value();
-    std::string const direction = params.direction;
+    auto const direction = params.direction;
     
     auto const& values = input.getAnalogTimeSeries();
     auto const& time_storage = input.getTimeStorage();
@@ -49,15 +43,15 @@ std::shared_ptr<DigitalEventSeries> analogEventThreshold(
         bool event_detected = false;
         
         // Check threshold crossing based on direction
-        if (direction == "positive") {
+        if (direction == AnalogEventThresholdParams::Direction::positive) {
             if (values[i] > threshold) {
                 event_detected = true;
             }
-        } else if (direction == "negative") {
+        } else if (direction == AnalogEventThresholdParams::Direction::negative) {
             if (values[i] < threshold) {
                 event_detected = true;
             }
-        } else if (direction == "absolute") {
+        } else if (direction == AnalogEventThresholdParams::Direction::absolute) {
             if (std::abs(values[i]) > std::abs(threshold)) {
                 event_detected = true;
             }

--- a/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.cpp
+++ b/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.cpp
@@ -16,13 +16,13 @@ std::shared_ptr<DigitalEventSeries> analogEventThreshold(
     
     // Validate parameters
     if (!params.isValidDirection()) {
-        std::cerr << "Invalid direction parameter: " << params.getDirection() << std::endl;
+        std::cerr << "Invalid direction parameter: " << params.direction << std::endl;
         return std::make_shared<DigitalEventSeries>();
     }
     
-    float const threshold = params.getThresholdValue();
-    float const lockout_time = params.getLockoutTime();
-    std::string const direction = params.getDirection();
+    float const threshold = params.threshold_value;
+    float const lockout_time = params.lockout_time.value();
+    std::string const direction = params.direction;
     
     auto const& values = input.getAnalogTimeSeries();
     auto const& time_storage = input.getTimeStorage();

--- a/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.hpp
+++ b/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.hpp
@@ -31,32 +31,18 @@ namespace WhiskerToolbox::Transforms::V2::Examples {
  */
 struct AnalogEventThresholdParams {
     // Threshold value for event detection
-    std::optional<float> threshold_value;
+    float threshold_value = 1.0f;
 
     // Direction of threshold crossing: "positive", "negative", or "absolute"
-    std::optional<std::string> direction;
+    std::string direction = "positive";
 
     // Lockout time (in same units as time series) to prevent multiple detections
     // Must be non-negative
-    std::optional<rfl::Validator<float, rfl::Minimum<0.0f>>> lockout_time;
-
-    // Helper methods to get values with defaults
-    float getThresholdValue() const {
-        return threshold_value.value_or(1.0f);
-    }
-
-    std::string getDirection() const {
-        return direction.value_or("positive");
-    }
-
-    float getLockoutTime() const {
-        return lockout_time.has_value() ? lockout_time.value().value() : 0.0f;
-    }
+    rfl::Validator<float, rfl::Minimum<0.0f>> lockout_time = 0.0f;
 
     // Validate direction string
     bool isValidDirection() const {
-        auto dir = getDirection();
-        return dir == "positive" || dir == "negative" || dir == "absolute";
+        return direction == "positive" || direction == "negative" || direction == "absolute";
     }
 };
 

--- a/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.hpp
+++ b/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.hpp
@@ -30,20 +30,17 @@ namespace WhiskerToolbox::Transforms::V2::Examples {
  * ```
  */
 struct AnalogEventThresholdParams {
+    enum class Direction { positive, negative, absolute };
+
     // Threshold value for event detection
     float threshold_value = 1.0f;
 
-    // Direction of threshold crossing: "positive", "negative", or "absolute"
-    std::string direction = "positive";
+    // Direction of threshold crossing
+    Direction direction = Direction::positive;
 
     // Lockout time (in same units as time series) to prevent multiple detections
     // Must be non-negative
     rfl::Validator<float, rfl::Minimum<0.0f>> lockout_time = 0.0f;
-
-    // Validate direction string
-    bool isValidDirection() const {
-        return direction == "positive" || direction == "negative" || direction == "absolute";
-    }
 };
 
 /**

--- a/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.test.cpp
+++ b/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.test.cpp
@@ -72,7 +72,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Happy Path",
     SECTION("Positive threshold, no lockout") {
         auto ats = analog_scenarios::positive_threshold_no_lockout();
         params.threshold_value = 1.0f;
-        params.direction = "positive";
+        params.direction = AnalogEventThresholdParams::Direction::positive;
         params.lockout_time = 0.0f;
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -90,7 +90,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Happy Path",
     SECTION("Positive threshold, with lockout") {
         auto ats = analog_scenarios::positive_threshold_with_lockout();
         params.threshold_value = 1.0f;
-        params.direction = "positive";
+        params.direction = AnalogEventThresholdParams::Direction::positive;
         params.lockout_time = 150.0f;
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -104,7 +104,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Happy Path",
     SECTION("Negative threshold, no lockout") {
         auto ats = analog_scenarios::negative_threshold_no_lockout();
         params.threshold_value = -1.0f;
-        params.direction = "negative";
+        params.direction = AnalogEventThresholdParams::Direction::negative;
         params.lockout_time = 0.0f;
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -118,7 +118,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Happy Path",
     SECTION("Negative threshold, with lockout") {
         auto ats = analog_scenarios::negative_threshold_with_lockout();
         params.threshold_value = -1.0f;
-        params.direction = "negative";
+        params.direction = AnalogEventThresholdParams::Direction::negative;
         params.lockout_time = 150.0f;
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -132,7 +132,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Happy Path",
     SECTION("Absolute threshold, no lockout") {
         auto ats = analog_scenarios::absolute_threshold_no_lockout();
         params.threshold_value = 1.0f;
-        params.direction = "absolute";
+        params.direction = AnalogEventThresholdParams::Direction::absolute;
         params.lockout_time = 0.0f;
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -146,7 +146,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Happy Path",
     SECTION("Absolute threshold, with lockout") {
         auto ats = analog_scenarios::absolute_threshold_with_lockout();
         params.threshold_value = 1.0f;
-        params.direction = "absolute";
+        params.direction = AnalogEventThresholdParams::Direction::absolute;
         params.lockout_time = 150.0f;
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -160,7 +160,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Happy Path",
     SECTION("No events expected (threshold too high)") {
         auto ats = analog_scenarios::no_events_high_threshold();
         params.threshold_value = 10.0f;
-        params.direction = "positive";
+        params.direction = AnalogEventThresholdParams::Direction::positive;
         params.lockout_time = 0.0f;
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -172,7 +172,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Happy Path",
     SECTION("All events expected (threshold very low, no lockout)") {
         auto ats = analog_scenarios::all_events_low_threshold();
         params.threshold_value = 0.1f;
-        params.direction = "positive";
+        params.direction = AnalogEventThresholdParams::Direction::positive;
         params.lockout_time = 0.0f;
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -196,7 +196,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Edge Cases",
     SECTION("Empty analog time series") {
         auto ats = analog_scenarios::empty_signal();
         params.threshold_value = 1.0f;
-        params.direction = "positive";
+        params.direction = AnalogEventThresholdParams::Direction::positive;
         params.lockout_time = 0.0f;
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -209,7 +209,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Edge Cases",
     SECTION("Lockout time larger than series duration") {
         auto ats = analog_scenarios::lockout_larger_than_duration();
         params.threshold_value = 1.0f;
-        params.direction = "positive";
+        params.direction = AnalogEventThresholdParams::Direction::positive;
         params.lockout_time = 1000.0f;  // Much larger than series
         
         result_events = registry.executeContainerTransform<AnalogTimeSeries, DigitalEventSeries, AnalogEventThresholdParams>(
@@ -222,7 +222,7 @@ TEST_CASE("V2 Container Transform: Analog Event Threshold - Edge Cases",
     SECTION("Cancellation support") {
         auto ats = analog_scenarios::all_events_low_threshold();
         params.threshold_value = 0.1f;
-        params.direction = "positive";
+        params.direction = AnalogEventThresholdParams::Direction::positive;
         params.lockout_time = 0.0f;
         
         // Set cancellation flag
@@ -257,7 +257,7 @@ TEST_CASE("V2 Container Transform: AnalogEventThresholdParams - JSON Loading",
         auto params = result.value();
         
         REQUIRE(params.threshold_value == 2.5f);
-        REQUIRE(params.direction == "negative");
+        REQUIRE(params.direction == AnalogEventThresholdParams::Direction::negative);
         REQUIRE(params.lockout_time.value() == 100.0f);
     }
     
@@ -270,7 +270,7 @@ TEST_CASE("V2 Container Transform: AnalogEventThresholdParams - JSON Loading",
         auto params = result.value();
         
         REQUIRE(params.threshold_value == 1.0f);
-        REQUIRE(params.direction == "positive");
+        REQUIRE(params.direction == AnalogEventThresholdParams::Direction::positive);
         REQUIRE(params.lockout_time.value() == 0.0f);
     }
     
@@ -286,7 +286,7 @@ TEST_CASE("V2 Container Transform: AnalogEventThresholdParams - JSON Loading",
         auto params = result.value();
         
         REQUIRE(params.threshold_value == 3.0f);
-        REQUIRE(params.direction == "absolute");
+        REQUIRE(params.direction == AnalogEventThresholdParams::Direction::absolute);
         REQUIRE(params.lockout_time.value() == 0.0f);  // Default
     }
     
@@ -304,7 +304,7 @@ TEST_CASE("V2 Container Transform: AnalogEventThresholdParams - JSON Loading",
     SECTION("JSON round-trip preserves values") {
         AnalogEventThresholdParams original;
         original.threshold_value = 1.5f;
-        original.direction = "positive";
+        original.direction = AnalogEventThresholdParams::Direction::positive;
         original.lockout_time = rfl::Validator<float, rfl::Minimum<0.0f>>(50.0f);
         
         // Serialize
@@ -317,7 +317,7 @@ TEST_CASE("V2 Container Transform: AnalogEventThresholdParams - JSON Loading",
         
         // Verify values match
         REQUIRE(recovered.threshold_value == 1.5f);
-        REQUIRE(recovered.direction == "positive");
+        REQUIRE(recovered.direction == AnalogEventThresholdParams::Direction::positive);
         REQUIRE(recovered.lockout_time.value() == 50.0f);
     }
 }

--- a/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.test.cpp
+++ b/src/TransformsV2/algorithms/AnalogEventThreshold/AnalogEventThreshold.test.cpp
@@ -256,9 +256,9 @@ TEST_CASE("V2 Container Transform: AnalogEventThresholdParams - JSON Loading",
         REQUIRE(result);
         auto params = result.value();
         
-        REQUIRE(params.getThresholdValue() == 2.5f);
-        REQUIRE(params.getDirection() == "negative");
-        REQUIRE(params.getLockoutTime() == 100.0f);
+        REQUIRE(params.threshold_value == 2.5f);
+        REQUIRE(params.direction == "negative");
+        REQUIRE(params.lockout_time.value() == 100.0f);
     }
     
     SECTION("Load empty JSON (uses defaults)") {
@@ -269,9 +269,9 @@ TEST_CASE("V2 Container Transform: AnalogEventThresholdParams - JSON Loading",
         REQUIRE(result);
         auto params = result.value();
         
-        REQUIRE(params.getThresholdValue() == 1.0f);
-        REQUIRE(params.getDirection() == "positive");
-        REQUIRE(params.getLockoutTime() == 0.0f);
+        REQUIRE(params.threshold_value == 1.0f);
+        REQUIRE(params.direction == "positive");
+        REQUIRE(params.lockout_time.value() == 0.0f);
     }
     
     SECTION("Load with only some fields") {
@@ -285,9 +285,9 @@ TEST_CASE("V2 Container Transform: AnalogEventThresholdParams - JSON Loading",
         REQUIRE(result);
         auto params = result.value();
         
-        REQUIRE(params.getThresholdValue() == 3.0f);
-        REQUIRE(params.getDirection() == "absolute");
-        REQUIRE(params.getLockoutTime() == 0.0f);  // Default
+        REQUIRE(params.threshold_value == 3.0f);
+        REQUIRE(params.direction == "absolute");
+        REQUIRE(params.lockout_time.value() == 0.0f);  // Default
     }
     
     SECTION("Reject negative lockout time") {
@@ -316,9 +316,9 @@ TEST_CASE("V2 Container Transform: AnalogEventThresholdParams - JSON Loading",
         auto recovered = result.value();
         
         // Verify values match
-        REQUIRE(recovered.getThresholdValue() == 1.5f);
-        REQUIRE(recovered.getDirection() == "positive");
-        REQUIRE(recovered.getLockoutTime() == 50.0f);
+        REQUIRE(recovered.threshold_value == 1.5f);
+        REQUIRE(recovered.direction == "positive");
+        REQUIRE(recovered.lockout_time.value() == 50.0f);
     }
 }
 

--- a/tests/TransformsV2/test_parameter_schema.test.cpp
+++ b/tests/TransformsV2/test_parameter_schema.test.cpp
@@ -168,17 +168,17 @@ TEST_CASE("extractParameterSchema - AnalogEventThresholdParams", "[transforms][v
     auto * threshold = schema.field("threshold_value");
     REQUIRE(threshold != nullptr);
     CHECK(threshold->type_name == "float");
-    CHECK(threshold->is_optional);
+    CHECK_FALSE(threshold->is_optional);
     CHECK(threshold->display_name == "Threshold Value");
 
     auto * direction = schema.field("direction");
     REQUIRE(direction != nullptr);
-    CHECK(direction->is_optional);
+    CHECK_FALSE(direction->is_optional);
 
     auto * lockout = schema.field("lockout_time");
     REQUIRE(lockout != nullptr);
     CHECK(lockout->type_name == "float");
-    CHECK(lockout->is_optional);
+    CHECK_FALSE(lockout->is_optional);
     // lockout_time has rfl::Minimum<0.0f> validator
     CHECK(hasValidator(lockout->raw_type_name));
     CHECK_FALSE(lockout->is_exclusive_min);// Minimum is inclusive


### PR DESCRIPTION
This addresses issue 250 by refactoring the options struct for `AnalogEventThreshold` to use default initializers instead of `std::optional`. It simplifies the parameter setup, prevents extraneous UI elements from being generated by `AutoParamWidget`, and updates dependent components and tests to correctly use the new direct fields. Tests ran successfully.

---
*PR created automatically by Jules for task [6716205762382574027](https://jules.google.com/task/6716205762382574027) started by @paulmthompson*